### PR TITLE
Enable Home Manager with flake

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -106,10 +106,6 @@
     isNormalUser = true;
     description = "Arthur Mckellar";
     extraGroups = [ "networkmanager" "wheel" ];
-    packages = with pkgs; [
-      firefox
-      hyprpaper waybar kitty rofi-wayland
-    ];
   };
 
   # -------------------------------------------------

--- a/flake.nix
+++ b/flake.nix
@@ -4,15 +4,25 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.05";
     nixos-hardware.url = "github:NixOS/nixos-hardware";
+    home-manager.url = "github:nix-community/home-manager";
+    home-manager.inputs.nixpkgs.follows = "nixpkgs";
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, nixos-hardware, ... }: {
+  outputs = { self, nixpkgs, nixos-hardware, home-manager, ... }: {
     nixosConfigurations.artsxps = nixpkgs.lib.nixosSystem {
       system = "x86_64-linux";
       modules = [
         nixos-hardware.nixosModules.dell-xps-15-9530
         ./configuration.nix
+        home-manager.nixosModules.home-manager
+        ({ config, pkgs, ... }: {
+          home-manager = {
+            useGlobalPkgs = true;
+            useUserPackages = true;
+            users.lucid = import ./home.nix;
+          };
+        })
       ];
     };
   };

--- a/home.nix
+++ b/home.nix
@@ -1,0 +1,15 @@
+{ config, pkgs, ... }:
+{
+  home.username = "lucid";
+  home.homeDirectory = "/home/lucid";
+
+  home.packages = with pkgs; [
+    firefox
+    hyprpaper
+    waybar
+    kitty
+    rofi-wayland
+  ];
+
+  home.stateVersion = "23.05";
+}


### PR DESCRIPTION
## Summary
- integrate home-manager into flake
- create a basic `home.nix`
- move user packages from `configuration.nix` to Home Manager

## Testing
- `nix flake check` *(fails: `nix` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851e9c2a74483298466dace5f859b3b

## Summary by Sourcery

Integrate Home Manager into the Nix flake setup to manage user configuration separately and migrate user packages into a dedicated home.nix file.

New Features:
- Add Home Manager as a flake input and enable its module in the NixOS configuration
- Create a home.nix file for managing per-user settings and packages

Enhancements:
- Move user package declarations from configuration.nix into the Home Manager configuration