### PR TITLE
Add window manager modules

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -9,6 +9,7 @@
     [ # Include the results of the hardware scan.
       # <nixos-hardware/dell/xps/15-9530>
       ./hardware-configuration.nix
+      ./modules/window-manager/window-manager.nix
     ];
 
 
@@ -41,49 +42,6 @@
     LC_TIME         = "en_NZ.UTF-8";
   };
 
-  # -------------------------------------------------
-  # NVIDIA + Wayland / Hyprland
-  # -------------------------------------------------
-  services.xserver.enable = false;         # pure Wayland session
-  services.xserver.videoDrivers = [ "nvidia" ];
-  hardware.opengl.enable = true;
-
-  hardware.nvidia = {
-    modesetting.enable = true;      # required for Wayland
-    powerManagement.enable = true;
-    open = false;                   # set to true if GPU supports the open driver
-    prime = {
-      offload.enable = true;        # hybrid graphics off-load
-      intelBusId  = "PCI:0:2:0";   # Intel iGPU (00:02.0)
-      nvidiaBusId = "PCI:1:0:0";   # NVIDIA dGPU (01:00.0)
-    };
-  };
-
-  programs.hyprland = {
-    enable = true;
-    xwayland.enable = true;         # XWayland for legacy apps
-    nvidiaPatches = true;           # extra patches for NVIDIA/Wayland
-  };
-
-  # ---------------------------------------------
-  # Display / Login manager (greetd + tuigreet)
-  # ---------------------------------------------
-  services.greetd = {
-    enable = true;
-    settings = {
-      default_session = {
-        command = "${pkgs.greetd.tuigreet}/bin/tuigreet --time --cmd Hyprland";
-        user = "greeter";
-      };
-    };
-  };
-
-  # XDG portals (screencast, file‑open dialogs, etc.)
-  xdg.portal = {
-    enable = true;
-    extraPortals = [ pkgs.xdg-desktop-portal-wlr ];
-  };
-
   # Libinput for touchpad / mouse
   # services.libinput.enable = true;
 
@@ -112,13 +70,13 @@
   # -------------------------------------------------
   nixpkgs.config.allowUnfree = true;
 
-  environment.sessionVariables = {
-    WLR_NO_HARDWARE_CURSOR = "1";              # avoids cursor corruption on NVIDIA
-    __GLX_VENDOR_LIBRARY_NAME = "nvidia";
-  };
 
   environment.systemPackages = with pkgs; [
     neovim wget git pciutils htop gh lazygit
+  ];
+
+  fonts.packages = with pkgs; [
+    jetbrains-mono
   ];
 
   # -------------------------------------------------

--- a/flake.nix
+++ b/flake.nix
@@ -7,9 +7,14 @@
     home-manager.url = "github:nix-community/home-manager";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";
     flake-utils.url = "github:numtide/flake-utils";
+    zenBrowser = {
+      url = "github:0xc000022070/zen-browser-flake";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.home-manager.follows = "home-manager";
+    };
   };
 
-  outputs = { self, nixpkgs, nixos-hardware, home-manager, ... }: {
+  outputs = { self, nixpkgs, nixos-hardware, home-manager, zenBrowser, ... }: {
     nixosConfigurations.artsxps = nixpkgs.lib.nixosSystem {
       system = "x86_64-linux";
       modules = [
@@ -20,10 +25,12 @@
           home-manager = {
             useGlobalPkgs = true;
             useUserPackages = true;
+            extraSpecialArgs = { inherit zenBrowser; };
             users.lucid = import ./home.nix;
           };
         })
       ];
+      specialArgs = { inherit zenBrowser; };
     };
   };
 }

--- a/home.nix
+++ b/home.nix
@@ -1,10 +1,15 @@
-{ config, pkgs, ... }:
+{ config, pkgs, zenBrowser, ... }:
 {
+  imports = [
+    ./modules/dev/developer.nix
+    ./modules/notes/notes.nix
+    ./modules/browsers/browsers.nix
+  ];
+
   home.username = "lucid";
   home.homeDirectory = "/home/lucid";
 
   home.packages = with pkgs; [
-    firefox
     hyprpaper
     waybar
     kitty

--- a/modules/browsers/browsers.nix
+++ b/modules/browsers/browsers.nix
@@ -1,0 +1,7 @@
+{ pkgs, zenBrowser, ... }:
+{
+  imports = [
+    ./firefox.nix
+    ./zen.nix
+  ];
+}

--- a/modules/browsers/firefox.nix
+++ b/modules/browsers/firefox.nix
@@ -1,0 +1,4 @@
+{ pkgs, ... }:
+{
+  home.packages = with pkgs; [ firefox ];
+}

--- a/modules/browsers/zen.nix
+++ b/modules/browsers/zen.nix
@@ -1,0 +1,7 @@
+{ pkgs, zenBrowser, ... }:
+{
+  imports = [
+    zenBrowser.homeModules.default
+  ];
+  programs.zen-browser.enable = true;
+}

--- a/modules/dev/developer.nix
+++ b/modules/dev/developer.nix
@@ -1,0 +1,7 @@
+{ pkgs, ... }:
+{
+  imports = [
+    ./neovim.nix
+    ./tmux.nix
+  ];
+}

--- a/modules/dev/neovim.nix
+++ b/modules/dev/neovim.nix
@@ -1,0 +1,4 @@
+{ pkgs, ... }:
+{
+  home.packages = with pkgs; [ neovim ];
+}

--- a/modules/dev/tmux.nix
+++ b/modules/dev/tmux.nix
@@ -1,0 +1,4 @@
+{ pkgs, ... }:
+{
+  home.packages = with pkgs; [ tmux ];
+}

--- a/modules/notes/notes.nix
+++ b/modules/notes/notes.nix
@@ -1,0 +1,7 @@
+{ pkgs, ... }:
+{
+  imports = [
+    ./obsidian.nix
+    ./pandoc.nix
+  ];
+}

--- a/modules/notes/obsidian.nix
+++ b/modules/notes/obsidian.nix
@@ -1,0 +1,4 @@
+{ pkgs, ... }:
+{
+  home.packages = with pkgs; [ obsidian ];
+}

--- a/modules/notes/pandoc.nix
+++ b/modules/notes/pandoc.nix
@@ -1,0 +1,4 @@
+{ pkgs, ... }:
+{
+  home.packages = with pkgs; [ pandoc ];
+}

--- a/modules/window-manager/hyprland.nix
+++ b/modules/window-manager/hyprland.nix
@@ -1,0 +1,43 @@
+{ config, pkgs, ... }:
+{
+  services.xserver.enable = false;
+  services.xserver.videoDrivers = [ "nvidia" ];
+  hardware.opengl.enable = true;
+
+  hardware.nvidia = {
+    modesetting.enable = true;
+    powerManagement.enable = true;
+    open = false;
+    prime = {
+      offload.enable = true;
+      intelBusId  = "PCI:0:2:0";
+      nvidiaBusId = "PCI:1:0:0";
+    };
+  };
+
+  programs.hyprland = {
+    enable = true;
+    xwayland.enable = true;
+    nvidiaPatches = true;
+  };
+
+  services.greetd = {
+    enable = true;
+    settings = {
+      default_session = {
+        command = "${pkgs.greetd.tuigreet}/bin/tuigreet --time --cmd Hyprland";
+        user = "greeter";
+      };
+    };
+  };
+
+  xdg.portal = {
+    enable = true;
+    extraPortals = [ pkgs.xdg-desktop-portal-wlr ];
+  };
+
+  environment.sessionVariables = {
+    WLR_NO_HARDWARE_CURSOR = "1";
+    __GLX_VENDOR_LIBRARY_NAME = "nvidia";
+  };
+}

--- a/modules/window-manager/plasma.nix
+++ b/modules/window-manager/plasma.nix
@@ -1,0 +1,8 @@
+{ config, pkgs, ... }:
+{
+  services.xserver.enable = true;
+  services.xserver.displayManager.sddm.enable = true;
+  services.xserver.desktopManager.plasma5.enable = true;
+
+  xdg.portal.enable = true;
+}

--- a/modules/window-manager/window-manager.nix
+++ b/modules/window-manager/window-manager.nix
@@ -1,0 +1,6 @@
+{ ... }:
+{
+  imports = [
+    ./hyprland.nix
+  ];
+}


### PR DESCRIPTION
## Summary
- create Hyprland and Plasma system modules under `modules/window-manager`
- add `window-manager.nix` aggregator importing Hyprland by default
- import the new window manager module from `configuration.nix`

## Testing
- `nix --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68521dfeab2c8329bf10ce38bc72225d

## Summary by Sourcery

Introduce a modular structure for NixOS and home-manager configurations by extracting window manager, browser, developer, and notes setups into dedicated modules, and update flake and main configuration files to import and aggregate these modules.

New Features:
- Modular window manager configuration with Hyprland and Plasma
- Aggregator module window-manager.nix to import Hyprland by default
- Modular browser support via browser modules including zen-browser and Firefox
- Modular home environment for developer tools and notes

Enhancements:
- Refactor configuration.nix to import new window-manager aggregator
- Update flake.nix to include zenBrowser input and pass through home-manager
- Refactor home.nix to import newly created modules and streamline package lists
- Add JetBrains Mono to system fonts