### PR TITLE
Set zsh shell with starship prompt

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -103,7 +103,11 @@
     isNormalUser = true;
     description = "Arthur Mckellar";
     extraGroups = [ "networkmanager" "wheel" ];
+    shell = pkgs.zsh;
   };
+  users.defaultUserShell = pkgs.zsh;
+
+  programs.zsh.enable = true;
 
   # -------------------------------------------------
   # Environment / Packages & Vars

--- a/modules/dev/developer.nix
+++ b/modules/dev/developer.nix
@@ -3,5 +3,6 @@
   imports = [
     ./neovim.nix
     ./tmux.nix
+    ./zsh.nix
   ];
 }

--- a/modules/dev/neovim.nix
+++ b/modules/dev/neovim.nix
@@ -7,4 +7,8 @@
   chmod -R u+w ~/.config/nvim
   '';
 
+  home.sessionVariables = {
+    EDITOR = "nvim";
+  };
+
 }

--- a/modules/dev/zsh.nix
+++ b/modules/dev/zsh.nix
@@ -1,0 +1,7 @@
+{ pkgs, ... }: {
+  programs.zsh = {
+    enable = true;
+    ohMyZsh.enable = true;
+  };
+  programs.starship.enable = true;
+}


### PR DESCRIPTION
## Summary
- set zsh as default shell
- enable starship prompt and zsh via new module
- export EDITOR=nvim
- add oh-my-zsh

## Testing
- `nix --extra-experimental-features 'nix-command flakes' run nixpkgs#nixfmt -- --version`
- `nix --extra-experimental-features 'nix-command flakes' run nixpkgs#nixfmt -- modules/dev/zsh.nix modules/dev/developer.nix modules/dev/neovim.nix configuration.nix`


------
https://chatgpt.com/codex/tasks/task_e_685cabcc923883299fc99e2d0d4bbb2b