### PR TITLE
Add syncthing through home-manager and integrate sops

### DIFF
--- a/artsxps/configuration.nix
+++ b/artsxps/configuration.nix
@@ -94,7 +94,7 @@
   };
 
   boot.kernelPackages = pkgs.linuxPackages_latest;
-   hardware.enableAllFirmware = true;
+  hardware.enableAllFirmware = true;
 
   # -------------------------------------------------
   # Users
@@ -116,8 +116,14 @@
 
 
   environment.systemPackages = with pkgs; [
-    wget git pciutils htop gh lazygit
+    wget git pciutils htop gh lazygit sops age syncthing
   ];
+
+  sops = {
+    age.keyFile = "/var/lib/sops-nix/key.txt";
+    age.generateKey = true;
+    defaultSopsFile = ../secrets/secrets.yaml;
+  };
 
  fonts.packages = with pkgs; [
     jetbrains-mono

--- a/flake.lock
+++ b/flake.lock
@@ -92,7 +92,28 @@
         "lazyvim-config": "lazyvim-config",
         "nixos-hardware": "nixos-hardware",
         "nixpkgs": "nixpkgs",
+        "sops-nix": "sops-nix",
         "zenBrowser": "zenBrowser"
+      }
+    },
+    "sops-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1750119275,
+        "narHash": "sha256-Rr7Pooz9zQbhdVxux16h7URa6mA80Pb/G07T4lHvh0M=",
+        "owner": "Mic92",
+        "repo": "sops-nix",
+        "rev": "77c423a03b9b2b79709ea2cb63336312e78b72e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Mic92",
+        "repo": "sops-nix",
+        "type": "github"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -18,19 +18,26 @@
       url = "github:LikelyLucid/lazyvim-dotfiles";
       flake = false;
       };
+
+    sops-nix = {
+      url = "github:Mic92/sops-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
-  outputs = { self, nixpkgs, nixos-hardware, home-manager, zenBrowser, lazyvim-config, ... }: {
+  outputs = { self, nixpkgs, nixos-hardware, home-manager, zenBrowser, lazyvim-config, sops-nix, ... }: {
     nixosConfigurations.artsxps = nixpkgs.lib.nixosSystem {
       system = "x86_64-linux";
       modules = [
         nixos-hardware.nixosModules.dell-xps-15-9530
         ./artsxps/configuration.nix
+        sops-nix.nixosModules.sops
         home-manager.nixosModules.home-manager
         ({ config, pkgs, ... }: {
           home-manager = {
             useGlobalPkgs = true;
             useUserPackages = true;
+            sharedModules = [ sops-nix.homeManagerModules.sops ];
             extraSpecialArgs = { inherit zenBrowser lazyvim-config; };
             users.lucid = import ./home.nix;
           };

--- a/home.nix
+++ b/home.nix
@@ -21,6 +21,17 @@
     fastfetch
   ];
 
+  services.syncthing = {
+    enable = true;
+    dataDir = "${config.home.homeDirectory}/Sync";
+    openDefaultPorts = true;
+  };
+
+  sops = {
+    age.keyFile = "/var/lib/sops-nix/key.txt";
+    defaultSopsFile = ./secrets/secrets.yaml;
+  };
+
   home.stateVersion = "23.05";
 
   }

--- a/secrets/README.md
+++ b/secrets/README.md
@@ -1,0 +1,3 @@
+# SOPS Secrets
+
+Store your encrypted `secrets.yaml` files here. Do not commit real secrets to version control.

--- a/secrets/secrets.yaml
+++ b/secrets/secrets.yaml
@@ -1,0 +1,1 @@
+# example secrets file


### PR DESCRIPTION
## Summary
- run Syncthing as a home-manager service instead of system level
- hook sops into home-manager so secrets work for user configuration
- keep system-wide secrets settings

## Testing
- `nix --extra-experimental-features 'nix-command flakes' flake show --no-update-lock-file`


------
https://chatgpt.com/codex/tasks/task_e_685e21ac0e4083298d146e6498606e7e