### PR TITLE
Add hypridle and hyprlock

### DIFF
--- a/modules/window-manager/hyprland-config.nix
+++ b/modules/window-manager/hyprland-config.nix
@@ -13,4 +13,26 @@
 
   services.playerctld.enable = true;
 
+  programs.hyprlock.enable = true;
+  services.hypridle = {
+    enable = true;
+    settings = {
+      general = {
+        lock_cmd = "hyprlock";
+        before_sleep_cmd = "hyprlock";
+      };
+
+      listener = [
+        {
+          timeout = 300;
+          on-timeout = "hyprlock";
+        }
+        {
+          timeout = 600;
+          on-timeout = "systemctl suspend";
+        }
+      ];
+    };
+  };
+
 }

--- a/modules/window-manager/hyprland.nix
+++ b/modules/window-manager/hyprland.nix
@@ -21,6 +21,9 @@
     # nvidiaPatches = true; # Not needed now, yahoo
   };
 
+  programs.hyprlock.enable = true;
+  services.hypridle.enable = true;
+
   services.greetd = {
     enable = true;
     settings = {


### PR DESCRIPTION
## Summary
- enable hyprlock and hypridle in Hyprland module
- configure hypridle and hyprlock in Hyprland home manager settings

## Testing
- `nix --extra-experimental-features 'nix-command flakes' flake check` *(fails: syntax error)*

------
https://chatgpt.com/codex/tasks/task_e_686109030dfc8329a496b488b0c2c44e

## Summary by Sourcery

Enable and configure hypridle and hyprlock services in the Hyprland modules to handle screen locking and automatic idleness timeouts.

New Features:
- Enable hyprlock in the Hyprland and Hyprland-config modules
- Enable hypridle in the Hyprland and Hyprland-config modules

Enhancements:
- Configure hypridle with default lock and suspend timeouts and specify the lock command before sleep