### PR TITLE
Manage dotfiles via home-manager

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -19,6 +19,11 @@
       flake = false;
       };
 
+    dotfiles = {
+      url = "github:LikelyLucid/dotfiles";
+      flake = false;
+    };
+
     sops-nix = {
       url = "github:Mic92/sops-nix";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -28,7 +33,7 @@
     nixos-wsl.inputs.nixpkgs.follows = "nixpkgs";
   };
 
-  outputs = { self, nixpkgs, nixos-hardware, home-manager, zenBrowser, lazyvim-config, sops-nix, nixos-wsl, ... }: {
+  outputs = { self, nixpkgs, nixos-hardware, home-manager, zenBrowser, lazyvim-config, dotfiles, sops-nix, nixos-wsl, ... }: {
     nixosConfigurations.artsxps = nixpkgs.lib.nixosSystem {
       system = "x86_64-linux";
       modules = [
@@ -41,12 +46,12 @@
             useGlobalPkgs = true;
             useUserPackages = true;
             sharedModules = [ sops-nix.homeManagerModules.sops ];
-            extraSpecialArgs = { inherit zenBrowser lazyvim-config; };
+            extraSpecialArgs = { inherit zenBrowser lazyvim-config dotfiles; };
             users.lucid = import ./home.nix;
           };
         })
       ];
-      specialArgs = { inherit zenBrowser lazyvim-config; };
+      specialArgs = { inherit zenBrowser lazyvim-config dotfiles; };
     };
 
     nixosConfigurations.wsl = nixpkgs.lib.nixosSystem {
@@ -61,12 +66,12 @@
             useGlobalPkgs = true;
             useUserPackages = true;
             sharedModules = [ sops-nix.homeManagerModules.sops ];
-            extraSpecialArgs = { inherit lazyvim-config; };
+            extraSpecialArgs = { inherit lazyvim-config dotfiles; };
             users.lucid = import ./wsl/home.nix;
           };
         })
       ];
-      specialArgs = { inherit lazyvim-config; };
+      specialArgs = { inherit lazyvim-config dotfiles; };
     };
   };
 }

--- a/home.nix
+++ b/home.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, zenBrowser, lazyvim-config, ... }:
+{ config, pkgs, zenBrowser, lazyvim-config, dotfiles, ... }:
 
 {
   imports = [
@@ -6,6 +6,7 @@
     ./modules/dev/developer.nix
     ./modules/notes/notes.nix
     ./modules/browsers/browsers.nix
+    ./modules/dotfiles.nix
   ];
 
   home.username = "lucid";

--- a/modules/dotfiles.nix
+++ b/modules/dotfiles.nix
@@ -1,0 +1,12 @@
+{ config, lib, dotfiles, ... }:
+{
+  xdg.configFile."hypr".source = config.lib.file.mkOutOfStoreSymlink "${dotfiles}/hypr";
+  xdg.configFile."kitty".source = config.lib.file.mkOutOfStoreSymlink "${dotfiles}/kitty";
+  xdg.configFile."rofi".source = config.lib.file.mkOutOfStoreSymlink "${dotfiles}/rofi";
+  xdg.configFile."waybar".source = config.lib.file.mkOutOfStoreSymlink "${dotfiles}/waybar";
+  xdg.configFile."spotify-player".source = config.lib.file.mkOutOfStoreSymlink "${dotfiles}/spotify-player";
+  xdg.configFile."wallust".source = config.lib.file.mkOutOfStoreSymlink "${dotfiles}/wallust";
+  xdg.configFile."flameshot".source = config.lib.file.mkOutOfStoreSymlink "${dotfiles}/flameshot";
+  xdg.configFile."nvim".source = config.lib.file.mkOutOfStoreSymlink "${dotfiles}/nvim";
+}
+

--- a/modules/window-manager/hyprland-config.nix
+++ b/modules/window-manager/hyprland-config.nix
@@ -1,12 +1,12 @@
-{ pkgs, lazyvim-config, lib, ... }:
+{ pkgs, lazyvim-config, lib, dotfiles, ... }:
 {
  services.hyprpaper = {
     enable = true;
     settings = {
       ipc = "on";
       splash = false;
-      preload = "~/dotfiles/media/wallpapers/Wallpaper 4.jpg";
-      wallpaper = ",~/dotfiles/media/wallpapers/Wallpaper 4.jpg";
+      preload = "${dotfiles}/media/wallpapers/Wallpaper 4.jpg";
+      wallpaper = ",${dotfiles}/media/wallpapers/Wallpaper 4.jpg";
       };
   };
   wayland.windowManager.hyprland.extraConfig = "exec-once = hyprpaper &";

--- a/wsl/home.nix
+++ b/wsl/home.nix
@@ -1,7 +1,8 @@
-{ pkgs, lazyvim-config, ... }:
+{ pkgs, lazyvim-config, dotfiles, ... }:
 {
   imports = [
     ../modules/dev/developer.nix
+    ../modules/dotfiles.nix
   ];
 
   home.username = "lucid";


### PR DESCRIPTION
## Summary
- add `modules/dotfiles.nix` for linking configs from an external repository
- wire the new module into `home.nix` and imported in `wsl/home.nix`
- include `dotfiles` flake input and pass through `extraSpecialArgs`
- adjust wallpaper path to use `dotfiles` input directly
- fix linking to use `config.lib.file.mkOutOfStoreSymlink`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686376f8ca488329b9cfca87bb6a05fd

## Summary by Sourcery

Manage dotfiles via Home Manager by linking an external repository and updating relevant configs

New Features:
- Add `dotfiles` flake input and pass it through to Home Manager and NixOS configurations
- Introduce `modules/dotfiles.nix` to symlink various config directories from the external dotfiles repo

Enhancements:
- Integrate the dotfiles module into `home.nix` and `wsl/home.nix` imports
- Update Hyprland wallpaper paths to reference the dotfiles repository directly
- Use `config.lib.file.mkOutOfStoreSymlink` for all dotfile links in the new module