### PR TITLE
fix: support Beeper AppImage marker layout

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -93,11 +93,11 @@
     "dotfiles": {
       "flake": false,
       "locked": {
-        "lastModified": 1784079118,
-        "narHash": "sha256-Kg5nEbjQTPrRmYmsguIuaQxPMVXf+m1QZCFEjXVYbXc=",
+        "lastModified": 1784079232,
+        "narHash": "sha256-92NicR/PQ0QgqzvSdWMMk5C76PnfzlEJUteawT7foFA=",
         "owner": "LikelyLucid",
         "repo": "dotfiles",
-        "rev": "efc26b6a241550b4205536ba24fac13bc95e8b01",
+        "rev": "0d169959f58a3a890062bc33b4aebdbf0a182446",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -93,11 +93,11 @@
     "dotfiles": {
       "flake": false,
       "locked": {
-        "lastModified": 1784078848,
-        "narHash": "sha256-hnVZXAY4vESFA6TmEm1gONok6Ts4y+COxHZ4mOJ+YWE=",
+        "lastModified": 1784079118,
+        "narHash": "sha256-Kg5nEbjQTPrRmYmsguIuaQxPMVXf+m1QZCFEjXVYbXc=",
         "owner": "LikelyLucid",
         "repo": "dotfiles",
-        "rev": "773b494487386cb501b3c5cb5ee5b80946051d38",
+        "rev": "efc26b6a241550b4205536ba24fac13bc95e8b01",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -93,11 +93,11 @@
     "dotfiles": {
       "flake": false,
       "locked": {
-        "lastModified": 1784079232,
-        "narHash": "sha256-92NicR/PQ0QgqzvSdWMMk5C76PnfzlEJUteawT7foFA=",
+        "lastModified": 1784079623,
+        "narHash": "sha256-fFE0vB//xvVlpCKLYcYbW+HSyq4phas02QwxhzF/fOE=",
         "owner": "LikelyLucid",
         "repo": "dotfiles",
-        "rev": "0d169959f58a3a890062bc33b4aebdbf0a182446",
+        "rev": "09d448ffa036eef71da89c2f2267efe8d2bbaae9",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -93,11 +93,11 @@
     "dotfiles": {
       "flake": false,
       "locked": {
-        "lastModified": 1782428000,
-        "narHash": "sha256-DCu+W6af204n5IDIs3TNA9R+c4IaTH1Rx9ozsjveYgA=",
+        "lastModified": 1784078848,
+        "narHash": "sha256-hnVZXAY4vESFA6TmEm1gONok6Ts4y+COxHZ4mOJ+YWE=",
         "owner": "LikelyLucid",
         "repo": "dotfiles",
-        "rev": "48cc7093ee2d2c053b5d559a34d81fdc7dbb2138",
+        "rev": "773b494487386cb501b3c5cb5ee5b80946051d38",
         "type": "github"
       },
       "original": {

--- a/modules/dev/tmux.nix
+++ b/modules/dev/tmux.nix
@@ -23,17 +23,29 @@
         # Reload config
         bind r source-file ~/.tmux.conf
 
-        # Status bar
-        set -g status-style "bg=#1e1e2e,fg=#cdd6f4"
-        set -g status-left "#[fg=#89b4fa,bold] #S "
-        set -g status-right "#[fg=#a6e3a1] %H:%M #[fg=#cba6f7]#(curl -s wttr.in/?format='%t') "
+        # Status bar: compact blocks matching Waybar
+        set -g status-position bottom
+        set -g status-interval 5
+        set -g status-left-length 30
+        set -g status-right-length 80
+        set -g status-style "bg=default,fg=#dfe9f6"
+        set -g status-left "#[bg=#00000d,fg=#dfe9f6,bold]  #S  #[default]"
+        set -g status-right "#[bg=#00000d,fg=#dfe9f6]   #(whoami)@#h  󰁹 #(cat /sys/class/power_supply/BAT0/capacity 2>/dev/null || printf -- '--')%%   %I:%M %p   %a %d %b  #[default]"
+
+        set -g window-status-separator " "
+        set -g window-status-format "#[bg=#00000d,fg=#dfe9f6]  #I #W#{?window_zoomed_flag, 󰊓,}  #[default]"
+        set -g window-status-current-format "#[bg=#89b4fa,fg=#00000d,bold]  #I #W#{?window_zoomed_flag, 󰊓,}  #[default]"
+        set -g window-status-activity-style "bg=#00000d,fg=#89b4fa,bold"
 
         # Pane borders
-        set -g pane-border-style "fg=#45475a"
+        set -g pane-border-style "fg=#00000d"
         set -g pane-active-border-style "fg=#89b4fa"
+        set -g pane-border-status off
 
-        # Messages
-        set -g message-style "bg=#313244,fg=#cdd6f4"
+        # Prompts and copy mode
+        set -g message-style "bg=#00000d,fg=#dfe9f6"
+        set -g message-command-style "bg=#89b4fa,fg=#00000d,bold"
+        set -g mode-style "bg=#89b4fa,fg=#00000d,bold"
 
         # Enable true color
         set -ga terminal-overrides ",xterm-256color:Tc"

--- a/modules/filesystems/juicefs.nix
+++ b/modules/filesystems/juicefs.nix
@@ -52,7 +52,10 @@
       };
     in
     {
-      environment.systemPackages = [ juicefs ];
+      environment.systemPackages = [
+        juicefs
+        pkgs.fuse
+      ];
 
       programs.fuse.userAllowOther = true;
 
@@ -71,6 +74,7 @@
 
         serviceConfig = {
           Type = "simple";
+          ExecStartPre = "${pkgs.coreutils}/bin/ln -sfn ${pkgs.fuse}/bin/fusermount /bin/fusermount";
           ExecStart = "${mount_juicefs}/bin/mount-juicefs";
           ExecStop = "${juicefs}/bin/juicefs umount /mnt/juicefs";
           CacheDirectory = "juicefs";

--- a/modules/filesystems/juicefs.nix
+++ b/modules/filesystems/juicefs.nix
@@ -46,6 +46,7 @@
             redis://redis.likelylucid.com:6379/2 \
             /mnt/juicefs \
             --cache-dir /var/cache/juicefs \
+            --umask 000 \
             -o allow_other
         '';
       };

--- a/modules/filesystems/juicefs.nix
+++ b/modules/filesystems/juicefs.nix
@@ -49,6 +49,27 @@
             -o allow_other
         '';
       };
+
+      prepare_juicefs = pkgs.writeShellApplication {
+        name = "prepare-juicefs";
+        runtimeInputs = [ pkgs.util-linux ];
+        text = ''
+          if findmnt --mountpoint /mnt/juicefs >/dev/null; then
+            umount --lazy /mnt/juicefs
+          fi
+          ${pkgs.coreutils}/bin/ln -sfn ${pkgs.fuse}/bin/fusermount /bin/fusermount
+        '';
+      };
+
+      cleanup_juicefs = pkgs.writeShellApplication {
+        name = "cleanup-juicefs";
+        runtimeInputs = [ pkgs.util-linux ];
+        text = ''
+          if findmnt --mountpoint /mnt/juicefs >/dev/null; then
+            umount --lazy /mnt/juicefs
+          fi
+        '';
+      };
     in
     {
       environment.systemPackages = [
@@ -73,9 +94,10 @@
 
         serviceConfig = {
           Type = "simple";
-          ExecStartPre = "${pkgs.coreutils}/bin/ln -sfn ${pkgs.fuse}/bin/fusermount /bin/fusermount";
+          ExecStartPre = "${prepare_juicefs}/bin/prepare-juicefs";
           ExecStart = "${mount_juicefs}/bin/mount-juicefs";
           ExecStop = "${juicefs}/bin/juicefs umount /mnt/juicefs";
+          ExecStopPost = "${cleanup_juicefs}/bin/cleanup-juicefs";
           CacheDirectory = "juicefs";
           CacheDirectoryMode = "0700";
           Restart = "on-failure";

--- a/modules/filesystems/juicefs.nix
+++ b/modules/filesystems/juicefs.nix
@@ -65,11 +65,7 @@
       systemd.services.juicefs = {
         description = "JuiceFS mount";
         wantedBy = [ "multi-user.target" ];
-        requires = [ "sops-install-secrets.service" ];
-        after = [
-          "network-online.target"
-          "sops-install-secrets.service"
-        ];
+        after = [ "network-online.target" ];
         wants = [ "network-online.target" ];
 
         serviceConfig = {

--- a/modules/filesystems/juicefs.nix
+++ b/modules/filesystems/juicefs.nix
@@ -1,0 +1,87 @@
+{ ... }:
+{
+  nixos.modules.artsxps =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      juicefs = pkgs.stdenvNoCC.mkDerivation {
+        pname = "juicefs";
+        version = "1.4.0";
+
+        src = pkgs.fetchurl {
+          url = "https://github.com/juicedata/juicefs/releases/download/v1.4.0/juicefs-1.4.0-linux-amd64.tar.gz";
+          hash = "sha256-be3XMEh+fawbEcWAFoKolpLy5rl4kLr3rJQ0B1ALhas=";
+        };
+
+        dontUnpack = true;
+        installPhase = ''
+          runHook preInstall
+
+          tar -xzf "$src"
+          install -Dm755 juicefs "$out/bin/juicefs"
+          ln -s juicefs "$out/bin/mount.juicefs"
+
+          runHook postInstall
+        '';
+
+        meta = {
+          description = "Distributed POSIX file system built on top of Redis and S3";
+          homepage = "https://www.juicefs.com/";
+          license = lib.licenses.asl20;
+          mainProgram = "juicefs";
+          platforms = [ "x86_64-linux" ];
+        };
+      };
+
+      mount_juicefs = pkgs.writeShellApplication {
+        name = "mount-juicefs";
+        text = ''
+          META_PASSWORD="$(<${config.sops.secrets.juicefs-meta-password.path})"
+          export META_PASSWORD
+          exec ${juicefs}/bin/juicefs mount \
+            redis://redis.likelylucid.com:6379/2 \
+            /mnt/juicefs \
+            --cache-dir /var/cache/juicefs \
+            -o allow_other
+        '';
+      };
+    in
+    {
+      environment.systemPackages = [ juicefs ];
+
+      programs.fuse.userAllowOther = true;
+
+      sops.secrets.juicefs-meta-password = {
+        mode = "0400";
+        restartUnits = [ "juicefs.service" ];
+      };
+
+      systemd.tmpfiles.rules = [ "d /mnt/juicefs 0755 root root -" ];
+
+      systemd.services.juicefs = {
+        description = "JuiceFS mount";
+        wantedBy = [ "multi-user.target" ];
+        requires = [ "sops-install-secrets.service" ];
+        after = [
+          "network-online.target"
+          "sops-install-secrets.service"
+        ];
+        wants = [ "network-online.target" ];
+
+        serviceConfig = {
+          Type = "simple";
+          ExecStart = "${mount_juicefs}/bin/mount-juicefs";
+          ExecStop = "${juicefs}/bin/juicefs umount /mnt/juicefs";
+          CacheDirectory = "juicefs";
+          CacheDirectoryMode = "0700";
+          Restart = "on-failure";
+          RestartSec = 5;
+          TimeoutStopSec = 60;
+        };
+      };
+    };
+}

--- a/modules/filesystems/juicefs.nix
+++ b/modules/filesystems/juicefs.nix
@@ -46,7 +46,6 @@
             redis://redis.likelylucid.com:6379/2 \
             /mnt/juicefs \
             --cache-dir /var/cache/juicefs \
-            --umask 000 \
             -o allow_other
         '';
       };

--- a/modules/home/desktop.nix
+++ b/modules/home/desktop.nix
@@ -104,35 +104,7 @@
         libnotify
         pavucontrol
         rofi
-        (pkgs.ncspot.overrideAttrs (old: {
-          cargoDeps = pkgs.runCommand "ncspot-vendor-librespot-cdn-fallback" { } ''
-                      cp -R ${old.cargoDeps} $out
-                      chmod -R u+w $out
-                      file="$out/source-registry-0/librespot-audio-0.8.0/src/fetch/mod.rs"
-                      substituteInPlace "$file" \
-                        --replace-fail 'Ok(r) => {
-                                response_streamer_url = Some((r, streamer, url));
-                                break;
-                            }
-                            Err(e) => warn!("Fetching {url} failed with error {e:?}, trying next"),' 'Ok(r) if r.status() == StatusCode::PARTIAL_CONTENT => {
-                                response_streamer_url = Some((r, streamer, url));
-                                break;
-                            }
-                            Ok(r) => warn!(
-                                "Fetching {url} returned {} (expected 206 Partial Content), trying next",
-                                r.status()
-                            ),
-                            Err(e) => warn!("Fetching {url} failed with error {e:?}, trying next"),'
-                      substituteInPlace "$file" \
-                        --replace-fail '
-                    let code = response.status();
-                    if code != StatusCode::PARTIAL_CONTENT {
-                        debug!("Opening audio file expected partial content but got: {code}");
-                        return Err(AudioFileError::StatusCode(code).into());
-                    }
-            ' ""
-          '';
-        }))
+        spotify-player
         swaynotificationcenter
         wallust
         waybar
@@ -216,28 +188,13 @@
             "timeout-critical": 0,
             "fit-to-screen": true,
             "keyboard-shortcuts": true,
-            "image-radius": 12,
-            "scripts": {
-              "kdeconnect-strip-br": {
-                "exec": "~/.config/swaync/scripts/kdeconnect-strip-br.sh",
-                "app-name": "KDE Connect"
-              }
-            }
+            "image-radius": 12
           }
         '';
       };
 
       home.file.".local/bin/notify-send" = {
         source = "${pkgs.libnotify}/bin/notify-send";
-        executable = true;
-      };
-
-      home.file.".config/swaync/scripts/kdeconnect-strip-br.sh" = {
-        text = ''
-          #!/bin/bash
-          # Strip <br> tags from KDE Connect notifications (swaync renders them as literal text)
-          echo "$3" | sed 's/<br>/\n/gi; s/<br\/>/\n/gi; s/<br \/>/\n/gi'
-        '';
         executable = true;
       };
 

--- a/modules/networking/tailscale.nix
+++ b/modules/networking/tailscale.nix
@@ -10,6 +10,11 @@
         enable = true;
         package = pkgs.tailscale;
         authKeyFile = config.sops.secrets.tailscale-auth-key.path;
+        extraUpFlags = [
+          "--ssh"
+          "--exit-node=lucidsserver"
+          "--operator=lucid"
+        ];
         extraSetFlags = [
           "--ssh"
           "--operator=lucid"

--- a/modules/overlays.nix
+++ b/modules/overlays.nix
@@ -10,7 +10,48 @@
         in
         {
           helium = inputs.helium-browser.packages.${prev.stdenv.hostPlatform.system}.helium;
-          beeper = inputs.beeper.packages.${prev.stdenv.hostPlatform.system}.default;
+
+          # Beeper's current AppImage stores its AI2 marker at offset 1024,
+          # while nixpkgs' appimage-exec reads it from the ELF header.
+          beeper =
+            let
+              upstream = inputs.beeper.packages.${prev.stdenv.hostPlatform.system}.default;
+              pname = upstream.pname;
+              version = upstream.version;
+              src = prev.runCommand "${pname}-${version}-appimage-patched" { } ''
+                cp ${upstream.src} $out
+                chmod u+w $out
+                printf '\x41\x49\x02' | dd of=$out bs=1 seek=8 conv=notrunc
+              '';
+              appimageContents = prev.appimageTools.extract {
+                inherit pname version src;
+              };
+            in
+            prev.appimageTools.wrapAppImage rec {
+              inherit pname version;
+              src = appimageContents;
+              pkgs = prev;
+              nativeBuildInputs = [ prev.copyDesktopItems ];
+              desktopItem = prev.makeDesktopItem {
+                name = "beeper";
+                desktopName = "Beeper";
+                exec = "${pname} %u";
+                icon = "beepertexts.png";
+                type = "Application";
+                terminal = false;
+                comment = "The ultimate messaging app";
+                categories = [
+                  "Network"
+                  "Chat"
+                ];
+                mimeTypes = [ "x-scheme-handler/beeper" ];
+              };
+              extraInstallCommands = ''
+                mkdir -p $out/share/applications
+                cp ${desktopItem}/share/applications/*.desktop $out/share/applications/
+                cp -r ${appimageContents}/usr/share/icons $out/share
+              '';
+            };
 
           hyprland-canvas = py_pkgs.buildPythonPackage {
             pname = "hyprland-canvas";

--- a/modules/window-manager/hyprland-config.nix
+++ b/modules/window-manager/hyprland-config.nix
@@ -80,8 +80,8 @@
 
         hl.config({
           general = {
-            gaps_in = 5,
-            gaps_out = 20,
+            gaps_in = 6,
+            gaps_out = 18,
             border_size = 2,
             col = {
               active_border = { colors = { "rgba(33ccffee)", "rgba(00ff99ee)" }, angle = 45 },
@@ -92,21 +92,21 @@
             layout = "dwindle",
           },
           decoration = {
-            rounding = 10,
+            rounding = 8,
             rounding_power = 2,
             active_opacity = 1.0,
-            inactive_opacity = 0.9,
+            inactive_opacity = 0.94,
             shadow = {
               enabled = true,
-              range = 4,
+              range = 10,
               render_power = 3,
               color = "rgba(1a1a1aee)",
             },
             blur = {
               enabled = true,
-              size = 5,
+              size = 6,
               passes = 2,
-              vibrancy = 0.1696,
+              vibrancy = 0.12,
             },
           },
           animations = { enabled = true },
@@ -140,8 +140,8 @@
         hl.animation({ leaf = "global", enabled = true, speed = 10, bezier = "default" })
         hl.animation({ leaf = "border", enabled = true, speed = 5.39, bezier = "easeOutQuint" })
         hl.animation({ leaf = "windows", enabled = true, speed = 4.79, bezier = "easeOutQuint" })
-        hl.animation({ leaf = "windowsIn", enabled = true, speed = 4.1, bezier = "easeOutQuint", style = "popin 87%" })
-        hl.animation({ leaf = "windowsOut", enabled = true, speed = 1.49, bezier = "linear", style = "popin 87%" })
+        hl.animation({ leaf = "windowsIn", enabled = true, speed = 4.1, bezier = "easeOutQuint", style = "popin 94%" })
+        hl.animation({ leaf = "windowsOut", enabled = true, speed = 1.8, bezier = "quick", style = "popin 94%" })
         hl.animation({ leaf = "fadeIn", enabled = true, speed = 1.73, bezier = "almostLinear" })
         hl.animation({ leaf = "fadeOut", enabled = true, speed = 1.46, bezier = "almostLinear" })
         hl.animation({ leaf = "fade", enabled = true, speed = 3.03, bezier = "quick" })
@@ -373,22 +373,24 @@
             path = ${wallpaper_path}
             blur_passes = 3
             blur_size = 8
+            vibrancy = 0.12
           }
 
           input-field {
             monitor =
-            size = 300, 60
+            size = 320, 56
             outline_thickness = 2
-            dots_size = 0.2
-            dots_spacing = 0.35
+            rounding = 8
+            dots_size = 0.18
+            dots_spacing = 0.32
             outer_color = $wallust_accent
             inner_color = $wallust_bg_clear
             font_color = $wallust_fg
             fade_on_empty = false
-            placeholder_text = <i>password</i>
-            fail_text = <i>try again</i>
+            placeholder_text = <span>    password</span>
+            fail_text = <span>  authentication failed</span>
             fail_color = $wallust_fail
-            position = 0, -80
+            position = 0, -70
             halign = center
             valign = center
           }
@@ -406,13 +408,35 @@
 
           label {
             monitor =
-            text = Welcome back, Arthur
+            text = cmd[update:60000] date +"%A  ·  %d %B"
             color = $wallust_accent
-            font_size = 20
+            font_size = 16
             font_family = JetBrains Mono Nerd Font
-            position = 0, 45
+            position = 0, 48
             halign = center
             valign = center
+          }
+
+          label {
+            monitor =
+            text =   Arthur
+            color = $wallust_fg
+            font_size = 14
+            font_family = JetBrains Mono Nerd Font
+            position = 0, -135
+            halign = center
+            valign = center
+          }
+
+          label {
+            monitor =
+            text = cmd[update:5000] sh -c 'printf "󰁹  %s%%" "$(cat /sys/class/power_supply/BAT0/capacity 2>/dev/null || echo --)"'
+            color = $wallust_fg
+            font_size = 14
+            font_family = JetBrains Mono Nerd Font
+            position = -28, -24
+            halign = right
+            valign = top
           }
         '';
 

--- a/secrets/secrets.yaml
+++ b/secrets/secrets.yaml
@@ -1,6 +1,7 @@
 tailscale-auth-key: ENC[AES256_GCM,data:R8V/+1mTA3UndGha8xe/EwZUwdVwjBRKlFiYjqfcZ+84V+pld4l04OHDHmTXiL0zQa1C77D54VJuaIfe1w==,iv:uIHt5GEKxeYsx0eazeqZRE7S42NcSVe6XPlbWMXtfRM=,tag:a/HxqAS1hxM1RS48ISF2Mg==,type:str]
 opencode-api-key: ENC[AES256_GCM,data:Bnj2mriZR3qpXZ58TdKd74ohCR+Xw7A0uwmPDk+UVX4Hw+CJkw0zNrSHq+dYPwgByACDHO6ryEfrSXjGNfn8docJaw==,iv:1BztMtOUCHKX2PFKB9Z7xXqqnGZ7LXMgU/3Sq7Ane3s=,tag:AiSv31DxpNrMbfv1a4klPg==,type:str]
 hermes-env: ENC[AES256_GCM,data:Az2ZNXV7IWQ8kNzh5KbBjz1hXWw+zEP+mRUwxprJ6DgVoldwcTrkwLYNVU/ywV/8C2qjiZlSlg9tHzX1S+TLHPkgXp5PHa2UVAfnGNVaeQ8JA4YLvttI,iv:mAzwWtDbOBp7YoBwKGhSsk6xdUtTsDUBKvFrO6tZqDs=,tag:hmmuGQRalSE3LrgFYXEqIA==,type:str]
+juicefs-meta-password: ENC[AES256_GCM,data:uciEYIl+QM7GOe2OVY/ZdrF8XFZvZJR4Doaq7MrMZa3ALDX+p2Zef7owmJjXWfaH,iv:wffIoGrfib1Etm97JYRetMzGquM4mF8hncrIPXSlFpE=,tag:USSKhhh9pZZBP+ADgX+Nkg==,type:str]
 sops:
     age:
         - enc: |
@@ -12,7 +13,7 @@ sops:
             qHoh3FA8teK5O72NRcWQT3D1xv7vp5NQipp9gD5suMAapgu5GNfUZw==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1xy4x6qlc5vgqkh5vw4202h33k2z24ct0xr53kavnmsdem3u8gg2q8850sf
-    lastmodified: "2026-07-13T03:37:58Z"
-    mac: ENC[AES256_GCM,data:npu5CLmzp6EL9wm50dzNzkFqsjXyDTvFd5RQ3tvNVrLZ7OUa5fiaM81n2X2YiBqCbhN6vQaSzJAeMNyEb2EX7QGex1BY6mdNKNpt7ahzyw9IDAiyNHYrHeROTlnRSh6yRhV9eV6Q6mFr2WqJzregUlRtM1jOCXfMXijqbG6nL8g=,iv:q7KjlRTGY6Qsy8tBO5n0ScDk065QKW/a5MdTkU1ZDGE=,tag:iSbG7NhDcHBvKohZ2IxMRw==,type:str]
+    lastmodified: "2026-07-18T03:27:41Z"
+    mac: ENC[AES256_GCM,data:Y7pQw56S2iDaFRxjiL03BE5Epj81QydAJgWKNzDAfjMxRZrJm5s4kAdC/QQ7MDWbju8XlXp4L+23BDWdCu8E1IIeaaL0fqCPRW7vNwHsPOTiih4RibxE3JffxNKs6M7JN6xmA1M3dcFSmDf0bR/mimPOJLHuSuLK/Opuq0dqpn4=,iv:UhfkX4O7Fhdl/4xEJ7vPd2FA05aInXraMdoHvOcULzI=,tag:SKs2Aa/9LNNii+EcWRBcZQ==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.11.0


### PR DESCRIPTION
## Summary
- patch Beeper AppImages whose `AI\x02` marker is stored at offset 1024
- normalize the marker into the ELF header before nixpkgs extraction
- preserve the upstream Beeper version and hash dynamically

## Verification
- `nix flake check --no-warn-dirty`
- Beeper 4.2.972 extraction and package build succeed

## Summary by Sourcery

Integrate a custom Beeper AppImage overlay that adjusts the AI2 marker for nixpkgs compatibility while preserving upstream versioning and providing desktop integration.

New Features:
- Add a patched Beeper AppImage wrapper with desktop integration and icon/mime configuration.

Bug Fixes:
- Normalize Beeper's AppImage AI2 marker into the ELF header so it is correctly handled by nixpkgs' appimage-exec.

Enhancements:
- Derive Beeper package metadata and source dynamically from the upstream flake to preserve its version and hash.